### PR TITLE
Log the sizes of the generated structures

### DIFF
--- a/Data/Boltzmann/System/Sampler.hs
+++ b/Data/Boltzmann/System/Sampler.hs
@@ -96,19 +96,19 @@ genRandomStr = genRandomStr' . prepare
 sampleStr :: RandomGen g
           => PSystem Double
           -> String
-          -> Int -> Int -> Rand g Structure
+          -> Int -> Int -> Rand g (Structure, Int)
 
 sampleStr sys str lb ub = do
     sample <- runMaybeT (genRandomStr sys str ub)
     case sample of
         Nothing     -> sampleStr sys str lb ub
-        Just (x, s) -> if lb <= s then return x
+        Just (x, s) -> if lb <= s then return (x, s)
                                   else sampleStr sys str lb ub
 
 sampleStrIO :: PSystem Double
             -> String
             -> Int -> Int
-            -> IO Structure
+            -> IO (Structure, Int)
 
 sampleStrIO sys str lb ub =
         evalRandIO $ sampleStr sys str lb ub

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -374,7 +374,7 @@ samplerConf sys opts =
                f "No explicit @samples annotation. Sampling a single structure."
                return (lb, ub, n, gen)
 
-getSamples :: System Int -> [Flag] -> IO [Structure]
+getSamples :: System Int -> [Flag] -> IO [(Structure, Int)]
 getSamples sys opts = do
     (lb, ub, n, genT) <- samplerConf sys opts
     -- TODO: Consider having generic method of generating samples
@@ -415,7 +415,7 @@ runRenderer opts = do
     info "Writing dotfile output..."
 
     -- TODO: Consider rendering multiple structures.
-    dotfile <- toDotFile cs (head samples)
+    dotfile <- toDotFile cs (fst $ head samples)
     T.putStrLn dotfile
 
 runTuner :: [Flag] -> IO ()


### PR DESCRIPTION
Sometimes it's nice to have access to the sizes of the generated trees without having to parse the output.
This patch adds one line of log (with verbosity level "info") with theses sizes.

What do you think about adding this to bb?