### PR TITLE
Handle slashed in bb-build's --output

### DIFF
--- a/scripts/bin/bb-build
+++ b/scripts/bin/bb-build
@@ -32,9 +32,10 @@ def parse_spec(spec_file):
 
     return None
 
+
 @click.command()
 @click.option('--input', required=True, help='Input specification.')
-@click.option('--output', default='sampler', help='Sampler executable name.')
+@click.option('--output', default='sampler', help='path to the generated executable')
 @click.option('--force', is_flag=True, help='Whether to use the force.')
 def run(input, output, force):
     output = Path(output).absolute()

--- a/scripts/bin/bb-build
+++ b/scripts/bin/bb-build
@@ -7,6 +7,8 @@ import tempfile
 import shutil
 import subprocess
 
+from pathlib import Path
+
 def toIO(gen_type):
     return f"sample{gen_type}IO"
 
@@ -35,7 +37,8 @@ def parse_spec(spec_file):
 @click.option('--output', default='sampler', help='Sampler executable name.')
 @click.option('--force', is_flag=True, help='Whether to use the force.')
 def run(input, output, force):
-    
+    output = Path(output).absolute()
+
     with open(input, 'r') as spec_file:
 
         gen_type = parse_spec(spec_file)
@@ -62,13 +65,13 @@ def run(input, output, force):
                 return
 
             cabal_location =  os.path.join(dirpath, "sampler-template.cabal")
-            subprocess.call(["sed", "-i", f"s/bb-sampler/{output}/g", cabal_location])
+            subprocess.call(["sed", "-i", f"s/bb-sampler/{output.name}/g", cabal_location])
             
             main_module = os.path.join(dirpath, "app", "Main.hs")
             subprocess.call(["sed", "-i", f"s/SAMPLE_COMMAND/{toIO(gen_type)}/g", main_module])
 
             click.echo(f"Compiling sampler.")
-            subprocess.call(["stack", "install", "--local-bin-path", script_path], cwd=dirpath)
+            subprocess.call(["stack", "install", "--local-bin-path", output.parent], cwd=dirpath)
            
         finally:
             click.echo("Done.")


### PR DESCRIPTION
As far as I understad, the current semantics of the --output flag is to
expect an executable name (without any slash) and the generated
executable would be copied to scripts/bin/ inside boltzmann brain's source tree

This seems counter intuitive to me. Instead I expected the following
command:

> bb-build --input something --output /path/to/blah.exe

to generate an executable named blah.exe in the directory /path/to.
This patch implement this semantics.

What to you think of it?

By the way, I like the new interface of boltzmann brain better, congrats for that! It simplifies things a lot compared the old interface with the medulla middleware (although there are still some quirks I'll report in other issues)